### PR TITLE
Remove duplicated interface StateDefinition

### DIFF
--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -61,13 +61,6 @@ export interface LocalStore<TState, TAction extends PayloadAction = Redux.AnyAct
   getState: () => TState;
 }
 
-/**
- * Typed Reducer method aka extends Redux.Reducer<TState>
- */
-export interface StateDefinition<TState, TPayload extends ActionPayload = void> extends TypedReducer<TState, TPayload> {
-  stateName: string;
-}
-
 export type TransitionMethod<TState, TPayload extends ActionPayload = void> = (
   localStore: LocalStore<TState>,
   arg: TPayload,


### PR DESCRIPTION
"npm run build" complains about this interface with following error : 

[!] (plugin rpt2) Error: C:/sources/git/local/redux-automata/src/core/common.ts(51,18): semantic error TS2428: All declarations of 'StateDefinition' must have identical type parameters.

This interface already exists in line 52 with same signature.